### PR TITLE
Add support for more datasets in training script

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -83,7 +83,9 @@ def setup_hf_dataset(args, dataset_text_field: Optional[str] = None):
 
     # assumes we only have a train split
     if "validation" not in dataset.keys():
-        dataset = dataset["train"].train_test_split(test_size=0.1)  # TODO: make this size configurable
+        dataset = dataset["train"].train_test_split(
+            test_size=args.validation_split_size
+        )  # TODO: make this size configurable
         dataset["validation"] = dataset["test"]
         del dataset["test"]
 
@@ -94,7 +96,7 @@ def setup_hf_dataset(args, dataset_text_field: Optional[str] = None):
     dataset = dataset.remove_columns([col for col in dataset["train"].column_names if col != "input_ids"])
     dataset.set_format("np")
 
-    return dataset
+    return dataset["train"], dataset["validation"]
 
 
 def get_tokenizer(args):

--- a/dataset.py
+++ b/dataset.py
@@ -1,19 +1,65 @@
 import string
+from typing import Optional
 
 import datasets
 import torch
 from torch.utils.data import DataLoader
+from transformers import AutoTokenizer
+
+
+def chunk_dataset(dataset, args, target_field: Optional[str] = None):
+    if target_field is None:
+        if hasattr(args, "dataset_text_field"):
+            target_field = args.dataset_text_field
+        else:
+            target_field = "text"
+
+    def map_fn(batch):
+        chunks = []
+        for example in batch[target_field]:
+            chunks += [example[i : i + args.sequence_length] for i in range(0, len(example), args.sequence_length)]
+
+        return {target_field: chunks}
+
+    dataset = dataset.map(map_fn, batched=True)
+
+    return dataset
+
+
+def pretokenize_dataset(dataset, tokenizer: AutoTokenizer, args, target_field: Optional[str] = None):
+    if target_field is None:
+        if hasattr(args, "dataset_text_field"):
+            target_field = args.dataset_text_field
+        else:
+            target_field = "text"
+
+    def map_fn(batch):
+        batch = batch[target_field]
+        # TODO: check if this is correct: we pad to +1 so when we slice for
+        # labels and input_ids, the size is equal to sequence_length
+        # should be fine so long as first element is SOS and last is EOS..
+        return tokenizer(batch, padding="max_length", max_length=args.sequence_length + 1)
+
+    dataset = dataset.map(map_fn, batched=True)
+
+    return dataset
 
 
 # get dataset from huggingface based on args.dataset
 # TODO: support datasets with advanced tokenizers, and pre-tokenisation
-def setup_dataset(args):
+def setup_text8_dataset(args, dataset_text_field: Optional[str] = None):
+    if dataset_text_field is None:
+        if hasattr(args, "dataset_text_field"):
+            dataset_text_field = args.dataset_text_field
+        else:
+            dataset_text_field = "text"
+
     lower, upper = string.ascii_lowercase[0], string.ascii_lowercase[-1]
     lower, upper = ord(lower), ord(upper)
     space_or_pad = upper + 1
 
     def transform_fn(batch):
-        batch = batch["text"]
+        batch = batch[dataset_text_field]
         batch = [example.ljust(args.sequence_length + 1) for example in batch]
         bytes = torch.tensor([[ord(c) for c in example] for example in batch], dtype=int)
         bytes[bytes == ord(" ")] = space_or_pad
@@ -22,13 +68,37 @@ def setup_dataset(args):
         return {"input_ids": input_ids}
 
     dataset = datasets.load_dataset(args.dataset)
-
-    # TODO: chunk dataset to args.sequence_length (potentially adding extra rows)
+    dataset = chunk_dataset(dataset, args, target_field="text")
 
     for split in ["train", "validation"]:
         dataset[split].set_transform(transform_fn)
 
     return dataset["train"], dataset["validation"]
+
+
+def setup_hf_dataset(args, dataset_text_field: Optional[str] = None):
+    dataset = datasets.load_dataset(args.dataset)
+
+    # TODO: check if splits already exist
+    if "validation" not in dataset.keys():
+        dataset = dataset["train"].train_test_split(test_size=0.1)  # TODO: make this configurable
+        dataset["validation"] = dataset["test"]
+        del dataset["test"]
+
+    tokenizer = get_tokenizer(args)
+
+    dataset = chunk_dataset(dataset, args, target_field=dataset_text_field)
+    dataset = pretokenize_dataset(dataset, tokenizer, args, target_field=dataset_text_field)
+    dataset = dataset.remove_columns([col for col in dataset["train"].column_names if col != "input_ids"])
+    dataset.set_format("np")
+
+    return dataset
+
+
+def get_tokenizer(args):
+    tokenizer = AutoTokenizer.from_pretrained("EleutherAI/gpt-neox-20b")
+    tokenizer.pad_token_id = tokenizer.eos_token_id
+    return tokenizer
 
 
 def setup_dataloaders(args, train_dataset, validation_dataset):
@@ -48,3 +118,10 @@ def setup_dataloaders(args, train_dataset, validation_dataset):
 
 def torch_to_np_batch(batch):
     return {k: v.numpy() for k, v in batch.items()}
+
+
+def setup_dataset(args, dataset_text_field: Optional[str] = None):
+    if "text8" in args.dataset:
+        return setup_text8_dataset(args, dataset_text_field=dataset_text_field)
+
+    return setup_hf_dataset(args, dataset_text_field=dataset_text_field)

--- a/train.py
+++ b/train.py
@@ -76,7 +76,6 @@ def create_step_fn(args, model, optimiser):
     opt_state = optimiser.init(eqx.filter(model, eqx.is_inexact_array))
 
     def loss_fn(model, batch):
-        # TODO: fix this as this actually results in -1 the sequence length
         input_ids, labels = jnp.copy(batch[:, :-1]), jnp.copy(batch[:, 1:])
         logits = jax.vmap(model[0])(input_ids)
         num_tokens = (labels != -100).sum()

--- a/train.py
+++ b/train.py
@@ -271,6 +271,10 @@ if __name__ == "__main__":
     parser.add_argument(
         "--dataset", type=str, default="afmck/text8-chunked1024", help="Dataset to use as on Huggingface hub."
     )
+    parser.add_argument("--dataset_subset", type=str, default=None, help="Subset of dataset to use.")
+    parser.add_argument(
+        "--dataset_text_field", type=str, default="text", help="Name of text field in dataset to tokenize."
+    )
     parser.add_argument("--batch_size", type=int, default=8, help="Batch size for training.")
     parser.add_argument(
         "--micro_batch_size",

--- a/train.py
+++ b/train.py
@@ -275,7 +275,9 @@ if __name__ == "__main__":
     parser.add_argument(
         "--dataset_text_field", type=str, default="text", help="Name of text field in dataset to tokenize."
     )
-    parser.add_argument("--batch_size", type=int, default=8, help="Batch size for training.")
+    parser.add_argument(
+        "--validation_split_size", type=float, default=0.1, help="Size of validation split as a percentage."
+    )
     parser.add_argument(
         "--micro_batch_size",
         type=int,
@@ -286,6 +288,7 @@ if __name__ == "__main__":
     parser.add_argument("--sequence_length", type=int, default=1024, help="Sequence length for training.")
 
     # optimiser args
+    parser.add_argument("--batch_size", type=int, default=8, help="Batch size for training.")
     parser.add_argument("--learning_rate", type=float, default=6e-4, help="Initial learning rate after warmup phase.")
     parser.add_argument("--end_learning_rate", type=float, default=1e-6, help="End learning rate.")
     parser.add_argument("--warmup_start_lr", type=float, default=1e-5, help="Warmup start learning rate.")


### PR DESCRIPTION
Achieved using Huggingface datasets. This should work with most text datasets on the Huggingface hub.

Currently no way to change tokenizer, defaults to the gpt neox tokenizer.